### PR TITLE
Use Dynamic Expiry Dates for SAS url

### DIFF
--- a/AIEnrichmentPipeline/infra/core/storage.tf
+++ b/AIEnrichmentPipeline/infra/core/storage.tf
@@ -57,8 +57,8 @@ resource "azurerm_storage_container" "deployments" {
 data "azurerm_storage_account_sas" "sas" {
   connection_string = azurerm_storage_account.releases.primary_connection_string
   https_only        = true
-  start             = "2019-01-01"
-  expiry            = "2021-12-31"
+  start             = join("-", [formatdate("YYYY", timestamp()), "01", "01"])
+  expiry            = join("-", [formatdate("YYYY", timestamp()) + 1, "12", "31"])
   resource_types {
     object    = true
     container = false


### PR DESCRIPTION
Fixes #49 

Sets the start and end dates for the SAS url to be related to today's date.
Start is the beginning of this year, and the expiry is the end of next year.

While another hard-coded date would have done the job, this is a longer term fix that should avoid any issues in the future.
(famous last words)